### PR TITLE
Jordon/update default command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ forge deploy whois.ts
 # Sign up for a forge account
 forge auth signup
 
-## Create a zod schema
-mkdir forge && touch forge/my_schema.ts
+## Create an example zod schema
+forge init
 
 # Test your endpoint
 forge test ./forge/my_schema.ts

--- a/forge/person.ts
+++ b/forge/person.ts
@@ -1,5 +1,4 @@
 import z from "zod";
-import { EndpointConfig } from "../src/types/endpointConfig";
 
 const PersonCategory = z.enum([
   "historical",
@@ -31,16 +30,23 @@ const PersonSchema = z.object({
 
 export default PersonSchema;
 
-export const config: EndpointConfig = {
+type EndpointConfig = {
   /** path to the endpoint. one word, no special characters */
-  path: "person",
+  path: string;
   /**
    * determines if the endpoint is available for public access
    * users must use their own OpenAI API key
    */
-  public: false,
+  public: boolean;
   /** name of the endpoint */
-  name: "Person",
+  name?: string;
   /** description of the endpoint */
+  description?: string;
+};
+
+export const config: EndpointConfig = {
+  path: "person",
+  public: false,
+  name: "Person",
   description: "A person in history or the present day",
 };

--- a/index.ts
+++ b/index.ts
@@ -3,6 +3,7 @@ import { hideBin } from "yargs/helpers";
 import auth from "./src/commands/auth";
 import deploy from "./src/commands/deploy";
 import docs from "./src/commands/docs";
+import init from "./src/commands/init";
 import keys from "./src/commands/key";
 import test from "./src/commands/test";
 import { config } from "./src/config/config";
@@ -11,12 +12,13 @@ import cWrap from "./src/utils/logging";
 // wrap(null) removes the default 80 character limit
 const cli = yargs(hideBin(process.argv)).scriptName("forge").wrap(null);
 // commands
-deploy(cli);
-// transform(cli);
-test(cli);
 auth(cli);
+deploy(cli);
 docs(cli);
+init(cli);
 keys(cli);
+test(cli);
+// transform(cli);
 
 cli.command("$0", "default", (args) => {
   console.log(

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import yargs from "yargs";
+import yargs, { CommandModule } from "yargs";
 import { hideBin } from "yargs/helpers";
 import auth from "./src/commands/auth";
 import deploy from "./src/commands/deploy";
@@ -20,17 +20,17 @@ keys(cli);
 test(cli);
 // transform(cli);
 
-cli.command(
-  "$0",
-  "default",
-  (args) => {},
-  (args) => {
+const defaultCommand: CommandModule = {
+  command: "$0",
+  describe: false,
+  handler: () => {
     console.log(
       `Welcome to Forge! Try running ${cWrap.fg(
         config.bin + " auth signup"
       )} or ${cWrap.fg(config.bin + " --help")} to get started.`
     );
-  }
-);
+  },
+};
+cli.command(defaultCommand);
 
 cli.parse();

--- a/index.ts
+++ b/index.ts
@@ -20,12 +20,17 @@ keys(cli);
 test(cli);
 // transform(cli);
 
-cli.command("$0", "default", (args) => {
-  console.log(
-    `Welcome to Forge! Try running ${cWrap.fg(
-      config.bin + " auth signup"
-    )} or ${cWrap.fg(config.bin + " --help")} to get started.`
-  );
-});
+cli.command(
+  "$0",
+  "default",
+  (args) => {},
+  (args) => {
+    console.log(
+      `Welcome to Forge! Try running ${cWrap.fg(
+        config.bin + " auth signup"
+      )} or ${cWrap.fg(config.bin + " --help")} to get started.`
+    );
+  }
+);
 
 cli.parse();

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,0 +1,15 @@
+import type { Argv } from "yargs";
+import init from "../controls/init";
+import cWrap from "../utils/logging";
+
+const initCommand = (cli: Argv) =>
+  cli.command(
+    "init",
+    `${cWrap.fm("Initiallize the ./forge directory with an example schema.")}`,
+    () => {},
+    (_args) => {
+      init();
+    }
+  );
+
+export default initCommand;

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,7 +5,8 @@ import cWrap from "../utils/logging";
 const initCommand = (cli: Argv) =>
   cli.command(
     "init",
-    `${cWrap.fm("Initiallize the ./forge directory with an example schema.")}`,
+    `${cWrap.fm("Initiallize the ./forge directory with an example schema.")}
+`,
     () => {},
     (_args) => {
       init();

--- a/src/controls/init.ts
+++ b/src/controls/init.ts
@@ -1,0 +1,29 @@
+import { existsSync } from "fs";
+import { copyFile, mkdir } from "fs/promises";
+import path from "path";
+
+const init = async () => {
+  const exampleFilePath = path.join(__dirname, "../../forge/person.ts");
+  const destinationDir = path.join(process.cwd(), "forge");
+  const destinationFilePath = destinationDir + "/person.schema.ts";
+
+  const dirExists = existsSync(destinationDir);
+
+  if (dirExists) {
+    console.log("Forge directory already exists.\n");
+  } else {
+    console.log("Creating forge directory...\n");
+    await mkdir(destinationDir);
+  }
+
+  console.log(
+    "Copying example file (person.schema.ts) to forge directory...\n"
+  );
+  await copyFile(exampleFilePath, destinationFilePath);
+  console.log(
+    "Created forge directory with example schema at:",
+    destinationFilePath
+  );
+};
+
+export default init;


### PR DESCRIPTION
# Fix for the default command
## Current Behavior
The console.log runs even if the `--help` flag is passed in. This leads to a bloated (and repeating) help log.
`forge` logs: 
```
Welcome to Forge! Try running forge auth signup or forge --help to get started.
```

`forge --help` logs:
```
Welcome to Forge! Try running forge auth signup or forge --help to get started.
forge

default

Commands:
  forge auth <action>            Manage authentication state with actions:
                                 signup         sign up for a forge account
                                 login          sign in to an existing forge account
                                 logout         log out of the current forge account
                                 update         update the username associated with the current forge account

  forge deploy <path-to-schema>  Deploy a schema to the Forge API.
                                 --path <path>  override the endpoint path

  forge docs                     List the url of your Swagger API docs.

  forge init                     Initiallize the ./forge directory with an example schema.

  forge key <action>             Manage your forge-associated keys with actions:
                                 copy           copy a key to your clipboard
                                 list           list the supported providers and key status
                                 set            set a key. defaults to setting your openAI key

  forge test <path-to-schema>    Run a prompt against a given schema to simulate a Forge endpoint.

  forge                          default  [default]

Options:
  --help     Show help  [boolean]
  --version  Show version number  [boolean]
```

## New Behavior
`forge` logs: 
```
Welcome to Forge! Try running forge auth signup or forge --help to get started.
```

`forge --help` logs:
```
forge

Commands:
  forge auth <action>            Manage authentication state with actions:
                                 signup         sign up for a forge account
                                 login          sign in to an existing forge account
                                 logout         log out of the current forge account
                                 update         update the username associated with the current forge account

  forge deploy <path-to-schema>  Deploy a schema to the Forge API.
                                 --path <path>  override the endpoint path

  forge docs                     List the url of your Swagger API docs.

  forge init                     Initiallize the ./forge directory with an example schema.

  forge key <action>             Manage your forge-associated keys with actions:
                                 copy           copy a key to your clipboard
                                 list           list the supported providers and key status
                                 set            set a key. defaults to setting your openAI key

  forge test <path-to-schema>    Run a prompt against a given schema to simulate a Forge endpoint.


Options:
  --help     Show help  [boolean]
  --version  Show version number  [boolean]
  ```